### PR TITLE
rules: fix indent of BinaryExpressions

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -649,6 +649,7 @@ module.exports = {
             CallExpression: {
                 arguments: DEFAULT_PARAMETER_INDENT
             },
+            BinaryExpression: 1,
             MemberExpression: 1,
             ArrayExpression: 1,
             ObjectExpression: 1,
@@ -1091,19 +1092,12 @@ module.exports = {
             },
 
             "BinaryExpression, LogicalExpression"(node) {
+                const firstToken = sourceCode.getFirstToken(node);
                 const operator = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
 
-                /*
-                 * For backwards compatibility, don't check BinaryExpression indents, e.g.
-                 * var foo = bar &&
-                 *                   baz;
-                 */
-
-                const tokenAfterOperator = sourceCode.getTokenAfter(operator);
-
-                offsets.ignoreToken(operator);
-                offsets.ignoreToken(tokenAfterOperator);
-                offsets.setDesiredOffset(tokenAfterOperator, operator, 0);
+                if (!astUtils.isTokenOnSameLine(node.left, node.right)) {
+                  offsets.setDesiredOffset(operator, firstToken, 1)
+                }
             },
 
             "BlockStatement, ClassBody"(node) {

--- a/test/lib/rules/redent.js
+++ b/test/lib/rules/redent.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const {RuleTester} = require('eslint')
-const rule = require('../../../lib/rules/redent')
+const rule = require('../../../lib/rules/indent')
 
 const Suite = new RuleTester({
   parserOptions: {
@@ -15,7 +15,7 @@ const Suite = new RuleTester({
 
 Suite.run('redent', rule, {
   valid: [
-    {code: 'var x = {\n  a: 1\n, b: 2\n}\n'}
+    {code: 'var x = {\n  a: 1\n, b: 2\n}\nvar a = 1\n  + 5'}
   ]
 , invalid: [{
     code: 'var x = {\n  a: 1\n  , b: 2\n}\n'


### PR DESCRIPTION
This fixes things like

```
var a = 1
+ 1
```

to be

```
var a = 1
  + 1
```

Semver: major