### PR TITLE
check-require: properly handle nested requires

### DIFF
--- a/lib/rules/check-require.js
+++ b/lib/rules/check-require.js
@@ -81,6 +81,19 @@ module.exports = {
           }
         } else {
           // Non local module
+          let idx = name.indexOf('/')
+          if (idx !== -1) {
+            if (name[0] === '@') {
+              // Take the first and second
+              idx = name.indexOf('/', idx + 1)
+              if (idx !== -1) {
+                name = name.substring(0, idx)
+              }
+            } else {
+              name = name.substring(0, idx)
+            }
+          }
+
           if (internalModules.has(name)) return
           if (has(pkg.dependencies, name)) return
           if (has(pkg.devDependencies, name)) return

--- a/test/lib/rules/check-require.js
+++ b/test/lib/rules/check-require.js
@@ -23,6 +23,7 @@ Suite.run('check-require', rule, {
   valid: [
     {code: 'const a = require("http")'}
   , {code: fixture}
+  , {code: 'var a = require("eslint/lib/rules/utils/ast-utils")'}
   ]
 , invalid: [{
     code: 'const thing = require("biscuits")'


### PR DESCRIPTION
Previously, `require("thing/file.js")` would trigger a lint error.
Now, it checks that the package alone is present.

Semver: patch