### PR TITLE
fix(rules): corrects an invalid options lookup in check-require

### DIFF
--- a/lib/rules/check-require.js
+++ b/lib/rules/check-require.js
@@ -53,7 +53,7 @@ module.exports = {
 
 , create(context) {
     // First we need to find the neareast package.json
-    const options = context.options[0] || {}
+    const options = context.options[1] || {}
     const root = options.root || process.cwd()
     const pkgPath = path.join(root, 'package.json')
     const pkgOnDisk = require(pkgPath)

--- a/test/lib/rules/check-require.js
+++ b/test/lib/rules/check-require.js
@@ -9,26 +9,49 @@ const rule = require('../../../lib/rules/check-require')
 const fixture_path = path.join(__dirname, '..', '..', 'fixture')
 const fixture = fs.readFileSync(fixture_path, 'utf8')
 
-const Suite = new RuleTester({
-  parserOptions: {
-    ecmaVersion: 2018
-  , sourceType: 'script'
-  }
-, rules: {
-    "check-require": 2
-  }
-})
+{
+  const Suite = new RuleTester({
+    parserOptions: {
+      ecmaVersion: 2018
+    , sourceType: 'script'
+    }
+  })
 
-Suite.run('check-require', rule, {
-  valid: [
-    {code: 'const a = require("http")'}
-  , {code: fixture}
-  , {code: 'var a = require("eslint/lib/rules/utils/ast-utils")'}
-  ]
-, invalid: [{
-    code: 'const thing = require("biscuits")'
-  , errors: [{
-      message: 'Missing dependency: "biscuits". Not listed in package.json'
+  Suite.run('check-require', rule, {
+    valid: [
+      {code: 'const a = require("http")'}
+    , {code: fixture}
+    , {code: 'var a = require("eslint/lib/rules/utils/ast-utils")'}
+    ]
+  , invalid: [{
+      code: 'const thing = require("biscuits")'
+    , errors: [{
+        message: 'Missing dependency: "biscuits". Not listed in package.json'
+      }]
     }]
-  }]
-})
+  })
+}
+
+{
+  const Suite = new RuleTester({
+    parserOptions: {
+      ecmaVersion: 2018
+    , sourceType: 'script'
+    }
+  })
+
+  Suite.run('check-require', rule, {
+    valid: [
+      {code: 'const a = require("http")'}
+    , {code: fixture}
+    , {code: 'const thing = require("biscuits")', options: ["always", {root: __dirname}]}
+    ]
+  , invalid: [{
+      code: 'var a = require("eslint/lib/rules/utils/ast-utils")'
+    , options: ["always", {root: __dirname}]
+    , errors: [{
+        message: 'Missing dependency: "eslint". Not listed in package.json'
+      }]
+    }]
+  })
+}

--- a/test/lib/rules/package.json
+++ b/test/lib/rules/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-package",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "biscuits": "^0.0.0"
+  }
+}


### PR DESCRIPTION
The eslint configs are and array of 1: level, 2: when condition and
3: rule config. The level is popped off making the second index to place
for configuration.

This fixes the index lookup and updates tests to pass inline options to
the rule with a custom package root location

Semver: patch