### PR TITLE
fix(indent): fixes string coercion bug in desired indent logic

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -434,17 +434,13 @@ class OffsetStorage {
                 );
             } else if (this._lockedFirstTokens.has(token)) {
                 const firstToken = this._lockedFirstTokens.get(token);
-                const tokenStart = firstToken.loc.start.column
-                const lineStart = this._tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column
+                const tokenStart = firstToken.loc.start.column;
+                const firstLineToken = this._tokenInfo.getFirstTokenOfLine(firstToken);
+                const lineStart = firstLineToken.loc.start.column;
+                const desired = this.getDesiredIndent(firstLineToken)
+                  + this._indentType.repeat(tokenStart - lineStart).length;
 
-                this._desiredIndentCache.set(
-                    token,
-
-                    // (indentation for the first element's line)
-                    this.getDesiredIndent(this._tokenInfo.getFirstTokenOfLine(firstToken)) +
-
-                        this._indentType.repeat(tokenStart - lineStart)
-                );
+                this._desiredIndentCache.set(token, desired)
             } else {
                 const offsetInfo = this._getOffsetDescriptor(token);
                 let offset = (

--- a/test/fixtures/range-error
+++ b/test/fixtures/range-error
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = function searchRequest(req, res) {
+
+  async.parallel(
+    async.reflect((callback) => { }),
+    function (err, esResults) {
+      esResults.forEach((next) => {
+        if (next.value)
+          meta = { ...meta, ...next.value.meta }
+      })
+    })
+}

--- a/test/lib/rules/redent.js
+++ b/test/lib/rules/redent.js
@@ -9,6 +9,7 @@ const rule = require('../../../lib/rules/indent')
 const fixture_path = path.join(__dirname, '..', '..', 'fixtures')
 const basic = fs.readFileSync(path.join(fixture_path, 'valid'), 'utf8')
 const chaining = fs.readFileSync(path.join(fixture_path, 'optional-chaining'), 'utf8')
+const rangeerror = fs.readFileSync(path.join(fixture_path, 'range-error'), 'utf8')
 const inconsistent_whitespace = fs.readFileSync(
   path.join(fixture_path, 'inconsistent-whitespace')
 , 'utf8'
@@ -17,18 +18,33 @@ const inconsistent_whitespace = fs.readFileSync(
 const Suite = new RuleTester({
   parserOptions: {
     ecmaVersion: 2020
-  , sourceType: 'module'
+  , sourceType: 'script'
   }
 , rules: {
-    "indent": 0
+    "indent": 0,
   }
 })
 
-Suite.run('redent', rule, {
+Suite.run('sensible/indent', rule, {
   valid: [
     {code: inconsistent_whitespace}
   , {code: chaining}
   , {code: basic}
+  , {
+      code: rangeerror
+    , options: [2, {
+        "FunctionExpression": {
+          "parameters": "first"
+        },
+        "FunctionDeclaration": {
+          "parameters": "first",
+          "body": 1
+        },
+        "CallExpression": {
+          "arguments": "first"
+        },
+      }]
+    }
   ]
 , invalid: [{
     code: 'var x = {\n  a: 1\n  , b: 2\n}\n'


### PR DESCRIPTION
There was a logic branch that was adding the current indent with the indent char rather than its length which resulted in the offest values being concatenated rather than added. This makes sure to reference the length of the indent rather than the indent itself

Fixes: gh-14