### PR TITLE
feat(check-require): add support for node namespaced modules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
       - name: Checkout

--- a/lib/rules/check-require.js
+++ b/lib/rules/check-require.js
@@ -3,8 +3,18 @@
 const path = require('path')
 const Module = require('module')
 
+const UNSAFE_MODULE = /^(?:_|internal)/
+const internalModules = new Set(Object.keys(process.binding('natives')).filter((name) => {
+  return !UNSAFE_MODULE.test(name)
+}))
+
 function has(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop)
+}
+
+function isBuiltin(name) {
+  if (typeof Module.isBuiltin === 'function') return Module.isBuiltin(name)
+  return internalModules.has(name)
 }
 
 function resolveFrom(fromDir, moduleId) {
@@ -21,8 +31,6 @@ function resolveFrom(fromDir, moduleId) {
     return null
   }
 }
-
-const internalModules = new Set(Object.keys(process.binding('natives')))
 
 module.exports = {
   meta: {
@@ -48,6 +56,7 @@ module.exports = {
   , messages: {
       missingDependency: 'Missing dependency: "{{name}}". Not listed in package.json'
     , invalidRequire: 'Missing require: {{path}}. Path does not exist'
+    , invalidNodeBuiltin: 'Invalid NodeJS builtin: "{{name}}". Module does not exist'
     }
   }
 
@@ -67,7 +76,15 @@ module.exports = {
     function visit(node) {
 
       function check(name) {
-        if (name[0] === '.' || name[0] === '/') {
+        if (name.startsWith('node:')) {
+          if (!isBuiltin(name)) {
+            context.report({
+              node
+            , messageId: 'invalidNodeBuiltin'
+            , data: {name}
+            })
+          }
+        } else if (name[0] === '.' || name[0] === '/') {
           // Local module
           const parent = path.dirname(context.getFilename())
           if (!resolveFrom(parent, name)) {
@@ -94,7 +111,7 @@ module.exports = {
             }
           }
 
-          if (internalModules.has(name)) return
+          if (isBuiltin(name)) return
           if (has(pkg.dependencies, name)) return
           if (has(pkg.devDependencies, name)) return
           if (has(pkg.peerDependencies, name)) return

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@codedependant/release-config-npm": "^1.0.0",
     "eslint": "^8.1.0",
     "mocha": "^8.3.2",
-    "semantic-release": "^17.4.2"
+    "semantic-release": "^17.4.2",
+    "semver": "^7.5.4"
   }
 }


### PR DESCRIPTION
Allows all valid builtin modules to pass check require, including namespaced ones. Will use the native module check if available. node has added a namespace to builtin modules ('node:X') which is currently not supported by this package.