### PR TITLE
fix: correctly calculate indents when using "first" setting

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -433,12 +433,18 @@ class OffsetStorage {
                     this._tokenInfo.getTokenIndent(token).length / this._indentSize
                 );
             } else if (this._lockedFirstTokens.has(token)) {
+                let offset = 0;
+                if (token.type === 'Punctuator' && token.value === ',' ) {
+                  offset -= 1
+                }
+
                 const firstToken = this._lockedFirstTokens.get(token);
                 const tokenStart = firstToken.loc.start.column;
                 const firstLineToken = this._tokenInfo.getFirstTokenOfLine(firstToken);
                 const lineStart = firstLineToken.loc.start.column;
                 const desired = this.getDesiredIndent(firstLineToken)
-                  + this._indentType.repeat(tokenStart - lineStart).length;
+                  + (this._indentType.repeat(tokenStart - lineStart).length) / this._indentSize
+                  + offset;
 
                 this._desiredIndentCache.set(token, desired)
             } else {
@@ -851,18 +857,23 @@ module.exports = {
                     // Skip holes in arrays
                     return;
                 }
+                const firstToken = getFirstToken(element)
                 if (offset === "off") {
 
                     // Ignore the first token of every element if the "off" option is used
-                    offsets.ignoreToken(getFirstToken(element));
+                    offsets.ignoreToken(firstToken);
                 }
 
                 // Offset the following elements correctly relative to the first element
                 if (index === 0) {
                     return;
                 }
-                if (offset === "first" && tokenInfo.isFirstTokenOfLine(getFirstToken(element))) {
-                    offsets.matchOffsetOf(getFirstToken(elements[0]), getFirstToken(element));
+                
+                const firstTokenOfLine = tokenInfo.getFirstTokenOfLine(firstToken);
+                const isFirstTokenOfLine = firstToken === firstTokenOfLine;
+                const isPunctuatedStartOfLine = (firstTokenOfLine.type === 'Punctuator' && firstTokenOfLine.value === ',' && sourceCode.getTokenAfter(firstTokenOfLine) === firstToken)
+                if (offset === "first" && (isFirstTokenOfLine || isPunctuatedStartOfLine)) {
+                    offsets.matchOffsetOf(getFirstToken(elements[0]), firstTokenOfLine);
                 } else {
                     const previousElement = elements[index - 1];
                     const firstTokenOfPreviousElement = previousElement && getFirstToken(previousElement);

--- a/test/fixtures/first
+++ b/test/fixtures/first
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = function searchRequest(req, res) {
+  console.log('hello'
+            , 'there',
+              console.log('my',
+                          'good'),
+              'friend')
+}

--- a/test/lib/rules/redent.js
+++ b/test/lib/rules/redent.js
@@ -14,6 +14,7 @@ const inconsistent_whitespace = fs.readFileSync(
   path.join(fixture_path, 'inconsistent-whitespace')
 , 'utf8'
 )
+const first = fs.readFileSync(path.join(fixture_path, 'first'), 'utf8')
 
 const Suite = new RuleTester({
   parserOptions: {
@@ -40,6 +41,14 @@ Suite.run('sensible/indent', rule, {
           "parameters": "first",
           "body": 1
         },
+        "CallExpression": {
+          "arguments": "first"
+        },
+      }]
+    }
+  , {
+      code: first
+    , options: [2, {
         "CallExpression": {
           "arguments": "first"
         },


### PR DESCRIPTION
When using the "first" setting to match indentation to the first token of a list, the calculation was returning the total indent length instead of the required multiples of indentation e.g. 20 instead of 10 if using double spaced indentation. Fixed by dividing the total length by the indent size.

Additionally ensures to match identation to the first token of a list when the first token of an element begins with a punctuator. E.g.
```
// always valid
func('hello',
     'there')

// previously invalid
func('hello'
   , 'there')
```