### PR TITLE
chore(pkg)!: add support for eslint 9, 10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
       - name: Checkout
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 20
       - run: npm install
 
       - name: Publish

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,4 +3,27 @@
 const path = require('path')
 const requireindex = require('requireindex')
 
-module.exports.rules = requireindex(path.join(__dirname, 'rules'))
+// Load all rules
+const rules = requireindex(path.join(__dirname, 'rules'))
+
+// Export for legacy config (ESLint < 9)
+module.exports.rules = rules
+
+// Export for flat config (ESLint >= 9)
+module.exports.default = {
+  rules
+}
+
+// Convenience exports for flat config
+module.exports.configs = {
+  recommended: {
+    plugins: {
+      sensible: {
+        rules
+      }
+    },
+    rules: {
+      'sensible/indent': ['error', 2]
+    }
+  }
+}

--- a/lib/rules/check-require.js
+++ b/lib/rules/check-require.js
@@ -85,8 +85,8 @@ module.exports = {
             })
           }
         } else if (name[0] === '.' || name[0] === '/') {
-          // Local module
-          const parent = path.dirname(context.getFilename())
+          // Local module - ESLint 10: use context.filename instead of context.getFilename()
+          const parent = path.dirname(context.filename || context.getFilename())
           if (!resolveFrom(parent, name)) {
             context.report({
               node

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -21,92 +21,106 @@ const createTree = require('functional-red-black-tree');
 //------------------------------------------------------------------------------
 
 const KNOWN_NODES = new Set([
-  'AssignmentExpression',
-  'AssignmentPattern',
-  'ArrayExpression',
-  'ArrayPattern',
-  'ArrowFunctionExpression',
-  'AwaitExpression',
+  // Statements
   'BlockStatement',
-  'BinaryExpression',
   'BreakStatement',
-  'CallExpression',
-  'CatchClause',
-  'ChainExpression',
-  'ClassBody',
-  'ClassDeclaration',
-  'ClassExpression',
-  'ConditionalExpression',
   'ContinueStatement',
-  'DoWhileStatement',
   'DebuggerStatement',
+  'DoWhileStatement',
   'EmptyStatement',
-  'ExperimentalRestProperty',
-  'ExperimentalSpreadProperty',
   'ExpressionStatement',
-  'ForStatement',
   'ForInStatement',
   'ForOfStatement',
+  'ForStatement',
   'FunctionDeclaration',
+  'IfStatement',
+  'LabeledStatement',
+  'ReturnStatement',
+  'SwitchStatement',
+  'ThrowStatement',
+  'TryStatement',
+  'VariableDeclaration',
+  'WhileStatement',
+  'WithStatement',
+
+  // Expressions
+  'ArrayExpression',
+  'ArrowFunctionExpression',
+  'AssignmentExpression',
+  'AwaitExpression',
+  'BinaryExpression',
+  'CallExpression',
+  'ChainExpression',
+  'ClassExpression',
+  'ConditionalExpression',
   'FunctionExpression',
   'Identifier',
-  'IfStatement',
+  'ImportExpression',
   'Literal',
-  'LabeledStatement',
   'LogicalExpression',
   'MemberExpression',
   'MetaProperty',
-  'MethodDefinition',
   'NewExpression',
   'ObjectExpression',
-  'ObjectPattern',
-  'PrivateIdentifier',
-  'Program',
-  'Property',
-  'PropertyDefinition',
-  'RestElement',
-  'ReturnStatement',
   'SequenceExpression',
-  'SpreadElement',
-  'Super',
-  'SwitchCase',
-  'SwitchStatement',
   'TaggedTemplateExpression',
-  'TemplateElement',
   'TemplateLiteral',
   'ThisExpression',
-  'ThrowStatement',
-  'TryStatement',
   'UnaryExpression',
   'UpdateExpression',
-  'VariableDeclaration',
-  'VariableDeclarator',
-  'WhileStatement',
-  'WithStatement',
   'YieldExpression',
-  'JSXFragment',
-  'JSXOpeningFragment',
-  'JSXClosingFragment',
-  'JSXIdentifier',
-  'JSXNamespacedName',
-  'JSXMemberExpression',
-  'JSXEmptyExpression',
-  'JSXExpressionContainer',
-  'JSXElement',
-  'JSXClosingElement',
-  'JSXOpeningElement',
-  'JSXAttribute',
-  'JSXSpreadAttribute',
-  'JSXText',
+
+  // Patterns
+  'ArrayPattern',
+  'AssignmentPattern',
+  'ObjectPattern',
+  'RestElement',
+  'SpreadElement',
+
+  // Classes (ES2015+)
+  'ClassBody',
+  'ClassDeclaration',
+  'MethodDefinition',
+  'PropertyDefinition',
+  'PrivateIdentifier',
+  'StaticBlock',  // ES2022
+  'AccessorProperty',  // ES2022
+
+  // Modules (ES2015+)
+  'ExportAllDeclaration',
   'ExportDefaultDeclaration',
   'ExportNamedDeclaration',
-  'ExportAllDeclaration',
   'ExportSpecifier',
   'ImportDeclaration',
-  'ImportSpecifier',
   'ImportDefaultSpecifier',
   'ImportNamespaceSpecifier',
-  'ImportExpression'
+  'ImportSpecifier',
+  'ImportAttribute',  // ES2025 (import assertions/attributes)
+
+  // Other
+  'CatchClause',
+  'Program',
+  'Property',
+  'Super',
+  'SwitchCase',
+  'TemplateElement',
+  'VariableDeclarator',
+
+  // JSX
+  'JSXAttribute',
+  'JSXClosingElement',
+  'JSXClosingFragment',
+  'JSXElement',
+  'JSXEmptyExpression',
+  'JSXExpressionContainer',
+  'JSXFragment',
+  'JSXIdentifier',
+  'JSXMemberExpression',
+  'JSXNamespacedName',
+  'JSXOpeningElement',
+  'JSXOpeningFragment',
+  'JSXSpreadAttribute',
+  'JSXText'
 ]);
 
 /*
@@ -681,7 +695,8 @@ module.exports = {
             }
         }
 
-        const sourceCode = context.getSourceCode();
+        // ESLint 10 change: use context.sourceCode instead of context.getSourceCode()
+        const sourceCode = context.sourceCode || context.getSourceCode();
         const tokenInfo = new TokenInfo(sourceCode);
         const offsets = new OffsetStorage(tokenInfo, indentSize, indentType === "space" ? " " : "\t");
         const parameterParens = new WeakSet();
@@ -1336,6 +1351,42 @@ module.exports = {
 
                     offsets.ignoreToken(sourceCode.getTokenAfter(colon));
                 }
+            },
+
+            PropertyDefinition(node) {
+                const firstToken = sourceCode.getFirstToken(node);
+                const maybeSemicolonToken = sourceCode.getLastToken(node);
+                let keyLastToken = null;
+
+                // Indent key name for computed properties
+                if (node.computed) {
+                    const bracketTokenL = sourceCode.getFirstTokenBetween(firstToken, node.key, astUtils.isOpeningBracketToken);
+                    const bracketTokenR = sourceCode.getTokenAfter(node.key, astUtils.isClosingBracketToken);
+
+                    keyLastToken = bracketTokenR;
+                    offsets.setDesiredOffset(bracketTokenL, firstToken, 0);
+                    offsets.setDesiredOffset(bracketTokenR, firstToken, 0);
+                    offsets.setDesiredOffsets(node.key.range, bracketTokenL, 1);
+                }
+
+                // Indent initializer
+                if (node.value) {
+                    const equalToken = sourceCode.getTokenBefore(node.value, astUtils.isEqToken);
+
+                    offsets.setDesiredOffset(equalToken, keyLastToken || firstToken, 1);
+                    offsets.setDesiredOffsets([equalToken.range[1], node.value.range[1]], equalToken, 1);
+
+                    if (astUtils.isSemicolonToken(maybeSemicolonToken)) {
+                        offsets.setDesiredOffset(maybeSemicolonToken, equalToken, 0);
+                    }
+                }
+            },
+
+            StaticBlock(node) {
+                const openingCurly = sourceCode.getFirstToken(node, { skip: 1 }); // skip "static"
+                const closingCurly = sourceCode.getLastToken(node);
+
+                addElementListIndent(node.body, openingCurly, closingCurly, 1);
             },
 
             SwitchStatement(node) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/esatterwhite/eslint-plugin-sensible#readme",
   "dependencies": {
-    "espree": "^9.0.0",
+    "espree": "^10.3.0",
     "esutils": "^2.0.3",
     "functional-red-black-tree": "^1.0.1",
     "lodash": "^4.17.21",
@@ -38,9 +38,12 @@
   },
   "devDependencies": {
     "@codedependant/release-config-npm": "^1.0.0",
-    "eslint": "^8.1.0",
-    "mocha": "^8.3.2",
+    "eslint": "^10.0.0",
+    "mocha": "^10.8.2",
     "semantic-release": "^17.4.2",
     "semver": "^7.5.4"
+  },
+  "peerDependencies": {
+    "eslint": ">=9.0.0"
   }
 }

--- a/test/lib/rules/check-require.js
+++ b/test/lib/rules/check-require.js
@@ -13,7 +13,7 @@ const node_version = semver.parse(process.versions.node)
 
 {
   const Suite = new RuleTester({
-    parserOptions: {
+    languageOptions: {
       ecmaVersion: 2018
     , sourceType: 'script'
     }
@@ -59,7 +59,7 @@ const node_version = semver.parse(process.versions.node)
 
 {
   const Suite = new RuleTester({
-    parserOptions: {
+    languageOptions: {
       ecmaVersion: 2018
     , sourceType: 'script'
     }

--- a/test/lib/rules/redent.js
+++ b/test/lib/rules/redent.js
@@ -16,7 +16,7 @@ const inconsistent_whitespace = fs.readFileSync(
 )
 
 const Suite = new RuleTester({
-  parserOptions: {
+  languageOptions: {
     ecmaVersion: 2020
   , sourceType: 'script'
   }
@@ -51,7 +51,6 @@ Suite.run('sensible/indent', rule, {
   , output: 'var x = {\n  a: 1\n, b: 2\n}\n'
   , errors: [{
       message: 'Expected indentation of 0 spaces but found 2.'
-    , type: 'Punctuator'
     }]
   }]
 })


### PR DESCRIPTION
Updates the package to support newer versions of eslint new
plugin structure and configuration setup. Attempted support at older
versions of eslint, but the minimum version is 9

BREAKING CHANGE: minimum version of eslint updated to 9